### PR TITLE
Fix a bug in the huggingface model

### DIFF
--- a/huggingface/internlm-xcomposer-4bit/modeling_InternLM_XComposer.py
+++ b/huggingface/internlm-xcomposer-4bit/modeling_InternLM_XComposer.py
@@ -378,7 +378,7 @@ conversation
                 **kwargs):
 
         samples = kwargs.get('samples')
-        has_img = 'images' in samples.keys()
+        has_img = 'image' in samples.keys()
 
         ### encode text
         text = self.align_text(samples, has_img=has_img)

--- a/huggingface/internlm-xcomposer-vl/modeling_InternLM_XComposer.py
+++ b/huggingface/internlm-xcomposer-vl/modeling_InternLM_XComposer.py
@@ -378,7 +378,7 @@ conversation
                 **kwargs):
 
         samples = kwargs.get('samples')
-        has_img = 'images' in samples.keys()
+        has_img = 'image' in samples.keys()
 
         ### encode text
         text = self.align_text(samples, has_img=has_img)

--- a/huggingface/internlm-xcomposer/modeling_InternLM_XComposer.py
+++ b/huggingface/internlm-xcomposer/modeling_InternLM_XComposer.py
@@ -378,7 +378,7 @@ conversation
                 **kwargs):
 
         samples = kwargs.get('samples')
-        has_img = 'images' in samples.keys()
+        has_img = 'image' in samples.keys()
 
         ### encode text
         text = self.align_text(samples, has_img=has_img)


### PR DESCRIPTION
When I was fine-tuning the model, the bug happened. The file `finetune/data_mix.py`, line 137, in `get_item`. The dictionary sample has the key `image`. But in the huggingface model, for example, the file `internlm-xcomposer-vl-7b/modeling_InternLM_XComposer.py`, line 381, in `forward`. `has_img = 'images' in samples.keys()` will never have the key named `images`. So we should change it to `has_img = 'image' in samples.keys()`.
![image](https://github.com/InternLM/InternLM-XComposer/assets/73413365/2d1c73dd-1d3c-4100-960f-d9a845d04010)
![image](https://github.com/InternLM/InternLM-XComposer/assets/73413365/a858c1fd-1966-4159-b9aa-3fd03d04dfec)

After change:
![image](https://github.com/InternLM/InternLM-XComposer/assets/73413365/dc3dc738-701e-411c-bebc-9228067024b8)
