### PR TITLE
Fix typos in README document

### DIFF
--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -167,7 +167,7 @@ CUDA_VISIBLE_DEVICES=0 python -u eval.py
  
 <details>
   <summary>
-    <b>AI2D results</b>
+    <b>ChartQA results</b>
   </summary>
 
 | Overall | Human | Augmented |


### PR DESCRIPTION
I found a typo in the README, where 'chartQA' was mistakenly written as 'AI2D', and I corrected it.