### PR TITLE
 Fix Tensor Dimension Mismatch in Padding Operation for Batch Processing

### DIFF
--- a/examples/batch_chat.py
+++ b/examples/batch_chat.py
@@ -66,7 +66,8 @@ with torch.cuda.amp.autocast():
         batch_inputs, batch_masks, batch_atten_masks = [], [], []
         for inputs, im_mask in zip(inputs_list, masks_list):
             if im_mask.shape[1] < max_len:
-                pad_embeds = torch.cat([pad_embed]*(max_len - im_mask.shape[1]))
+                pad_length = max_len - im_mask.shape[1]
+                pad_embeds = pad_embed.repeat(1, pad_length, 1) 
                 pad_masks = torch.tensor([0]*(max_len - im_mask.shape[1])).unsqueeze(0).cuda()
                 inputs = torch.cat([pad_embeds, inputs['inputs_embeds']], dim=1)
                 atten_masks = torch.cat([pad_masks, torch.ones_like(im_mask)], dim=1)

--- a/examples/batch_chat.py
+++ b/examples/batch_chat.py
@@ -24,7 +24,7 @@ meta_instruction = """You are an AI assistant whose name is InternLM-XComposer (
 img_paths = ['examples/image1.webp',
              'examples/image1.webp']
 questions = ['Please describe this image in detail.',
-             'What is the text in this images?']
+             'What is the text in this images? Please describe it in detail.']
 
 assert len(img_paths) == len(questions)
 


### PR DESCRIPTION
Previously, `pad_embeds` was incorrectly constructed by repeating the `pad_embed` tensor along the wrong dimension, leading to a size mismatch when attempting to concatenate it with `inputs['inputs_embeds']`.
The error message is as follows：
```
Process Process-1:
Traceback (most recent call last):
  File "/ML-A100/team/mm/shuyu/anaconda3/envs/intern_clean/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/ML-A100/team/mm/shuyu/anaconda3/envs/intern_clean/lib/python3.9/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/ML-A100/team/mm/shuyu/workspace/projects/InternLM-XComposer/cap_train.py", line 159, in inferCaptionsAndSave
    inputs = torch.cat([pad_embeds, inputs['inputs_embeds']], dim=1)
RuntimeError: Sizes of tensors must match except in dimension 1. Expected size 57 but got size 1 for tensor number 1 in the list.
FINISHED!
```
Modification: specifying the dimension as 1 when preparing pad_embeds. 

This issue was not triggered by the official examples due to the difference in token counts across batches is 1 .Therefore I increase the difference in token numbers between the two examples