### PR TITLE
Update requirements in install_CN.md

### DIFF
--- a/docs/install_CN.md
+++ b/docs/install_CN.md
@@ -19,7 +19,7 @@ pip3 install torch torchvision torchaudio
 **Step 3.** 安装需要的包
 
 ```bash
-pip install transformers==4.30.2 timm==0.4.12 sentencepiece==0.1.99 gradio==3.44.4 markdown2==2.4.10 xlsxwriter==3.1.2 einops
+pip install transformers==4.33.2 timm==0.4.12 sentencepiece==0.1.99 gradio==3.44.4 markdown2==2.4.10 xlsxwriter==3.1.2 einops
 ```
 
 ### 可选: 4-bit测试额外需要安装的包


### PR DESCRIPTION
fixes #241 
The requirement for `transformers` doesn't match in `install.md` and `install_CN.md`. The wrong version in `install_CN.md` will cause an error.