### PR TITLE
Update finetune.py for unify the the communication between the collator and InternLMXComposer2ForCausalLM.forward 

### DIFF
--- a/finetune/finetune.py
+++ b/finetune/finetune.py
@@ -139,8 +139,7 @@ class DataCollatorForSupervisedDataset:
         text_input, data_type = tuple(
             [instance[key] for instance in instances]
             for key in ('text_input', 'data_type'))
-        if 'image' not in instances[0]:
-            text_input = [instance['text_input'][0] for instance in instances]
+        # Keep the batch size as 1 per GPU
         batch = dict(
             text_input=text_input,
             data_type=data_type,
@@ -296,7 +295,7 @@ def train():
     # Start trainner
     trainer = Trainer(
         model=model, tokenizer=tokenizer, args=training_args, **data_module)
-
+    assert trainer.args.per_device_train_batch_size == 1, " keep 1 training batch per GPU for nested batch"
     trainer.train()
     trainer.save_state()
 


### PR DESCRIPTION
For **text-only** nad **text-image** forward process takes input of different shape in the in the modeling.py, we should try to keep all data from the dataloader and and remove the text only branches that takes only the first batch from the inner batch.

 This way the input of the `InternLMXComposer2ForCausalLM.forward` will be universally be (1, bs)
Inside the InternLMXComposer2ForCausalLM.forward
 In the image-text mode, `interleav_wrap` encodes the ['text_input'] of size (1, bs)
In the text-only mode, ['text_input'] is firstly squeezed into a list of size (bs,) `tokenizer` encode the reshaped text inputs.

The modified modeling file is attached.


With the nested inner batch unavoidable, we suggest to impose trainer.per_device_train_batch_size as 1.

The modified InternLMXComposer2ForCausalLM.forward function in the https://huggingface.co/internlm/internlm-xcomposer2d5-7b/blob/main/modeling_internlm_xcomposer2.py should be 
```
    def forward(self,
                input_ids: torch.LongTensor = None,
                attention_mask: Optional[torch.Tensor] = None,
                position_ids: Optional[torch.LongTensor] = None,
                past_key_values: Optional[List[torch.FloatTensor]] = None,
                inputs_embeds: Optional[torch.FloatTensor] = None,
                labels: Optional[torch.LongTensor] = None,
                use_cache: Optional[bool] = None,
                output_attentions: Optional[bool] = None,
                output_hidden_states: Optional[bool] = None,
                return_dict: Optional[bool] = None,
                **kwargs) -> Union[Tuple, CausalLMOutputWithPast]:
        r"""
        Args:
            labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
                Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
                config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
                (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
            kwargs['samples']['text_input] should have dimension 1 x bs
        Returns:
        """

        samples = kwargs.get('samples', None)
        if samples:
            infer_mode = samples.get('infer_mode', 'base')
            if samples['data_type'][0] == 'text':
                has_img = False
            elif samples['data_type'][0] == 'multi':
                has_img = True
            else:
                raise NotImplementedError

            # encode text
            text = samples['text_input']
            # encode image
            if has_img:
                image = samples['image'][0]
                bs = len(samples['text_input'][0])
                image_nums = []
                temp_image = []
                for im in image:
                    if type(im) is list:
                        image_nums.append(len(im))
                        temp_image.extend(im)
                    else:
                        image_nums.append(1)
                        temp_image.append(im)
                image = temp_image
                assert type(image) is list and len(image_nums) == bs

                to_regress_embeds, attention_mask, targets, im_mask = self.interleav_wrap(
                    image, text, image_nums)
            else:
                to_regress_tokens, targets = self.text2emb(
                    text[0], add_special_tokens=True)
                to_regress_embeds = self.model.tok_embeddings(
                    to_regress_tokens.input_ids)
                attention_mask = to_regress_tokens.attention_mask
                im_mask = torch.zeros(to_regress_embeds.shape[:2]).cuda()

            inputs_embeds = to_regress_embeds[:, :self.max_length]
            attention_mask = attention_mask[:, :self.max_length]
            targets = targets[:, :self.max_length]
            im_mask = im_mask[:, :self.max_length].bool()
            labels = targets
        else:
            im_mask = kwargs.get('im_mask', None)
            infer_mode = kwargs.get('infer_mode', 'base')
            if im_mask is None and inputs_embeds is not None:
                im_mask = torch.zeros(inputs_embeds.shape[:2]).to(
                    inputs_embeds.device)
                im_mask = im_mask.bool()

        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
        output_hidden_states = (
            output_hidden_states if output_hidden_states is not None else
            self.config.output_hidden_states)
        return_dict = return_dict if return_dict is not None else self.config.use_return_dict

        # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
        outputs = self.model(
            input_ids=input_ids,
            attention_mask=attention_mask,
            position_ids=position_ids,
            past_key_values=past_key_values,
            inputs_embeds=inputs_embeds,
            use_cache=use_cache,
            output_attentions=output_attentions,
            output_hidden_states=output_hidden_states,
            return_dict=return_dict,
            im_mask=im_mask,
            infer_mode=infer_mode,
        )

        hidden_states = outputs[0]
        logits = self.output(hidden_states)
        logits = logits.float()

        loss = None
        if labels is not None:
            # Shift so that tokens < n predict n
            shift_logits = logits[..., :-1, :].contiguous()
            shift_labels = labels[..., 1:].contiguous()
            # Flatten the tokens
            loss_fct = CrossEntropyLoss()
            shift_logits = shift_logits.view(-1, self.config.vocab_size)
            shift_labels = shift_labels.view(-1)
            # Enable model parallelism
            shift_labels = shift_labels.to(shift_logits.device)
            loss = loss_fct(shift_logits, shift_labels)

        if not return_dict:
            output = (logits, ) + outputs[1:]
            return (loss, ) + output if loss is not None else output

        return CausalLMOutputWithPast(
            loss=loss,
            logits=logits,
            past_key_values=outputs.past_key_values,
            hidden_states=outputs.hidden_states,
            attentions=outputs.attentions,
        )
```